### PR TITLE
Fix aws-sdk-core issue 'certificate verify failed'

### DIFF
--- a/lib/miam.rb
+++ b/lib/miam.rb
@@ -6,6 +6,8 @@ require 'singleton'
 require 'thread'
 
 require 'aws-sdk-core'
+Aws.use_bundled_cert!
+
 require 'ruby-progressbar'
 require 'parallel'
 require 'term/ansicolor'


### PR DESCRIPTION
On Mac OS X (and may be other platforms, didn't test), any usage
of aws-sdk-core seems to fail with the following message:
`[ERROR] SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed`
The fix is documented here https://github.com/aws/aws-sdk-core-ruby/issues/166#issuecomment-111603660