### PR TITLE
Tentative fix for issue #17

### DIFF
--- a/lib/miam/driver.rb
+++ b/lib/miam/driver.rb
@@ -455,11 +455,16 @@ class Miam::Driver
     yield unless @options[:dry_run]
   end
 
-  def user_id
-    @user_id ||= @iam.get_user.user.user_id
+  def account_id
+    if not @account_id
+        resp = @iam.list_users({max_items: 1})
+        arn = resp.users[0].arn
+        @account_id = arn.match('^arn:aws:iam::([0-9]{12}):.*$')[1]
+    end
+    @account_id
   end
 
   def policy_arn(policy_name)
-    "arn:aws:iam::#{user_id}:policy/#{policy_name}"
+    "arn:aws:iam::#{account_id}:policy/#{policy_name}"
   end
 end


### PR DESCRIPTION
This rewrites the policy_arn to use account_id instead of user_id.
I did not find a clean way to identify account_id 100% of time
without this ugly hack. (Esp. when using IAM identities +
switch roles).
I'd be interested in a clean way to do that.