### PR TITLE
Follow account password policy on make password

### DIFF
--- a/lib/miam/client.rb
+++ b/lib/miam/client.rb
@@ -129,7 +129,7 @@ class Miam::Client
     end
 
     if expected_login_profile and not actual_login_profile
-      expected_login_profile[:password] ||= @password_manager.identify(user_name, :login_profile)
+      expected_login_profile[:password] ||= @password_manager.identify(user_name, :login_profile, @driver.password_policy)
       @driver.create_login_profile(user_name, expected_login_profile)
       updated = true
     elsif not expected_login_profile and actual_login_profile

--- a/lib/miam/driver.rb
+++ b/lib/miam/driver.rb
@@ -438,6 +438,14 @@ class Miam::Driver
     end
   end
 
+  def password_policy
+    return @password_policy if instance_variable_defined?(:@password_policy)
+
+    @password_policy = @iam.get_account_password_policy.password_policy
+  rescue Aws::IAM::Errors::NoSuchEntity
+    @password_policy = nil
+  end
+
   private
 
   def encode_document(policy_document)


### PR DESCRIPTION
Use account password policy on `#mkpasswd`.

Guard errors on create account in the password policy attached account.