### PR TITLE
Handle Amazon Web Service China

### DIFF
--- a/lib/miam/exporter.rb
+++ b/lib/miam/exporter.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 class Miam::Exporter
   AWS_MANAGED_POLICY_PREFIX = 'arn:aws:iam::aws:'
+  AWS_CN_MANAGED_POLICY_PREFIX = 'arn:aws-cn:iam::aws:'
 
   def self.export(iam, options = {})
     self.new(iam, options).export
@@ -200,7 +201,7 @@ class Miam::Exporter
     result = {}
 
     Parallel.each(policies, :in_threads => @concurrency) do |policy|
-      if policy.arn.start_with?(AWS_MANAGED_POLICY_PREFIX)
+      if policy.arn.start_with?(AWS_MANAGED_POLICY_PREFIX) or policy.arn.start_with?(AWS_CN_MANAGED_POLICY_PREFIX)
         next
       end
 


### PR DESCRIPTION
AWS China has a different namespace - ARNs start with 'arn:aws-cn:...'
To properly detect AWS Managed Policies, we need to modify a little
the exporter.